### PR TITLE
Fix missing match on inet6 address family

### DIFF
--- a/syntax/junos.vim
+++ b/syntax/junos.vim
@@ -29,7 +29,7 @@ syn match junosConstant /\v(class\s)@<=[a-z-]+(;)@=/
 "   default applications
 syn match junosConstant /\vjunos-[a-z-]+/
 "   family
-syn match junosConstant /\v(family\s)@<=[a-z-]+(\s\{)@=/
+syn match junosConstant /\v(family\s)@<=[a-z-]+6?(\s\{)@=/
 "   file
 syn match junosConstant /\v(file\s)@<=[a-z-]+(\s\{)@=/
 "   log levels (also matches policy constant 'any')


### PR DESCRIPTION
Hi,
I've noticed that the inet6 address family isn't highlighted with vim-junos-syntax installed. Have a look if that fix works for you.

Regards,
Axel
